### PR TITLE
Fix AssignmentExpressionNode

### DIFF
--- a/print.js
+++ b/print.js
@@ -402,7 +402,7 @@
 	};
 
 	ast.AssignmentExpressionNode.prototype.print = function(indent, indentChar) {
-		return "(" + this.left.print("", "") + ") " + this.operator + " (" + this.right.print("", "") + ")";
+		return this.left.print("", "") + " " + this.operator + " (" + this.right.print("", "") + ")";
 	};
 
 	ast.UpdateExpressionNode.prototype.print = function(indent, indentChar) {


### PR DESCRIPTION
Fix AssignmentExpressionNode. The bug happens under some circumstances if you feed the parser with its own previous result, the reason being that if you prefix the left part of an assignation (which, by the way, is useless), since your parser supports multi-line expressions it will see it as the parameter of a previous function.
